### PR TITLE
Make "fluid_styled_responsive_images" compatible to lazyloading-libraries

### DIFF
--- a/Classes/Resource/Rendering/ImageRenderer.php
+++ b/Classes/Resource/Rendering/ImageRenderer.php
@@ -240,8 +240,9 @@ class ImageRenderer implements FileRendererInterface
 
         switch ($configuration->getLayoutKey()) {
             case 'srcset':
+            case 'data-srcset':
                 if (!empty($this->srcset)) {
-                    $tagBuilder->addAttribute('srcset', implode(', ', $this->srcset));
+                    $tagBuilder->addAttribute($configuration->getLayoutKey(), implode(', ', $this->srcset));
                 }
 
                 $tagBuilder->addAttribute('sizes', implode(', ', $this->sizes));


### PR DESCRIPTION
In order to use lazyload libraries, you need the attribute "data-srcset" instead of "srcset" (see: https://github.com/aFarkas/lazysizes). This could be achieved with a small change in ImageRenderer.php.
