### PR TITLE
Make "fluid_styled_responsive_images" compatible to lazyloading-libraries (2nd approach)

### DIFF
--- a/Classes/Resource/Rendering/ImageRenderer.php
+++ b/Classes/Resource/Rendering/ImageRenderer.php
@@ -241,10 +241,10 @@ class ImageRenderer implements FileRendererInterface
         switch ($configuration->getLayoutKey()) {
             case 'srcset':
                 if (!empty($this->srcset)) {
-                    $tagBuilder->addAttribute('srcset', implode(', ', $this->srcset));
+                    $tagBuilder->addAttribute($configuration->getAttributePrefix() . 'srcset', implode(', ', $this->srcset));
                 }
 
-                $tagBuilder->addAttribute('sizes', implode(', ', $this->sizes));
+                $tagBuilder->addAttribute($configuration->getAttributePrefix() . 'sizes', implode(', ', $this->sizes));
                 break;
             case 'data':
                 if (!empty($this->data)) {

--- a/Classes/Resource/Rendering/ImageRendererConfiguration.php
+++ b/Classes/Resource/Rendering/ImageRendererConfiguration.php
@@ -86,6 +86,11 @@ class ImageRendererConfiguration
                 ? $settings['layoutKey']
                 : 'default';
 
+        $this->settings['attributePrefix'] =
+            (isset($settings['attributePrefix']))
+                ? $settings['attributePrefix']
+                : '';
+
         $this->settings['sourceCollection'] =
             (isset($settings['sourceCollection']) && is_array($settings['sourceCollection']))
                 ? $settings['sourceCollection']
@@ -111,6 +116,14 @@ class ImageRendererConfiguration
     public function getLayoutKey()
     {
         return $this->settings['layoutKey'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getAttributePrefix()
+    {
+        return $this->settings['attributePrefix'];
     }
 
     /**


### PR DESCRIPTION
In order to use lazyload libraries, you need the attribute "data-srcset" instead of "srcset" (see: https://github.com/aFarkas/lazysizes). This could be achieved with some small changes.

Example typoscript:

``` typoscript
tt_content.textmedia.settings.responsive_image_rendering {
    layoutKey = srcset
    attributePrefix = data-
    sourceCollection {
        smallest {
            width = 264
            srcset = 264w
        }
        medium {
            width = 360
            srcset = 360w
        }
        large {
            width = 555
            srcset = 555w
        }
        larger {
            width = 737
            srcset = 737w
        }
        largest {
            width = 1140
            srcset = 1140w
            sizes = auto
        }
    }
}
```
