### PR TITLE
[TASK] Avoid sizes attribute if no srcset attribute set.

### DIFF
--- a/Classes/Resource/Rendering/ImageRenderer.php
+++ b/Classes/Resource/Rendering/ImageRenderer.php
@@ -242,9 +242,11 @@ class ImageRenderer implements FileRendererInterface
             case 'srcset':
                 if (!empty($this->srcset)) {
                     $tagBuilder->addAttribute('srcset', implode(', ', $this->srcset));
+                    if(!empty($this->sizes)) {
+                        $tagBuilder->addAttribute('sizes', implode(', ', $this->sizes));
+                    }
                 }
 
-                $tagBuilder->addAttribute('sizes', implode(', ', $this->sizes));
                 break;
             case 'data':
                 if (!empty($this->data)) {


### PR DESCRIPTION
To avoid the W3C validation error 

> The sizes attribute may be specified only if the srcset attribute is also present

For images in which no responsive rendering is necessary srcset attribute is not set, but sizes attribute is set.
Additional I check if sizes has value cause sizes must not be emtpy.
