### PR TITLE
[TASK] Avoid sizes attribute if no srcset attribute set

### DIFF
--- a/Classes/Resource/Rendering/ImageRenderer.php
+++ b/Classes/Resource/Rendering/ImageRenderer.php
@@ -242,9 +242,11 @@ class ImageRenderer implements FileRendererInterface
             case 'srcset':
                 if (!empty($this->srcset)) {
                     $tagBuilder->addAttribute('srcset', implode(', ', $this->srcset));
+                    if(!empty($this->sizes)) {
+                        $tagBuilder->addAttribute('sizes', implode(', ', $this->sizes));
+                    }
                 }
 
-                $tagBuilder->addAttribute('sizes', implode(', ', $this->sizes));
                 break;
             case 'data':
                 if (!empty($this->data)) {

--- a/Tests/Unit/Resource/Rendering/ImageRenderingTest.php
+++ b/Tests/Unit/Resource/Rendering/ImageRenderingTest.php
@@ -173,8 +173,9 @@ class ImageRendererTest extends UnitTestCase
         );
 
         $this->assertEquals(
-            '<img src="image.jpg" alt="alt" title="title" sizes="" />',
-            $result
+            '<img src="image.jpg" alt="alt" title="title" />',
+            $result,
+            'sizes-attribute is omitted when no sizes are given'
         );
     }
 


### PR DESCRIPTION
This one is #19 with an adjusted test set to assert on the attribute being
omitted when no sizes are given.