### PR TITLE
[TASK] Enable rendering of original size as biggest size

### DIFF
--- a/Classes/Resource/Rendering/ImageRenderer.php
+++ b/Classes/Resource/Rendering/ImageRenderer.php
@@ -173,6 +173,7 @@ class ImageRenderer implements FileRendererInterface
         $configuration = $this->getConfiguration();
 
         $ignoredWidths = [];
+        $validWidths = [];
 
         foreach ($configuration->getSourceCollection() as $sourceCollection) {
             try {
@@ -192,6 +193,10 @@ class ImageRenderer implements FileRendererInterface
                     throw new \RuntimeException();
                 }
 
+                $width = (int)$sourceCollection['width'];
+                $validWidths[$width]['dataKey'] = $sourceCollection['dataKey'];
+                $validWidths[$width]['srcset'] = $sourceCollection['srcset'];
+
                 $localProcessingConfiguration = $defaultProcessConfiguration;
                 $localProcessingConfiguration['width'] = $sourceCollection['width'];
 
@@ -208,7 +213,7 @@ class ImageRenderer implements FileRendererInterface
             }
         }
 
-        if ($this->getMinKeyFromArray($ignoredWidths)) {
+        if ($this->getMinKeyFromArray($ignoredWidths) && !empty($validWidths)) {
             $width = $this->getMinKeyFromArray($ignoredWidths);
 
             $url = $configuration->getAbsRefPrefix() . $originalFile->getPublicUrl();

--- a/Classes/Resource/Rendering/ImageRenderer.php
+++ b/Classes/Resource/Rendering/ImageRenderer.php
@@ -216,7 +216,15 @@ class ImageRenderer implements FileRendererInterface
         if ($this->getMinKeyFromArray($ignoredWidths) && !empty($validWidths)) {
             $width = $this->getMinKeyFromArray($ignoredWidths);
 
-            $url = $configuration->getAbsRefPrefix() . $originalFile->getPublicUrl();
+            $localProcessingConfiguration = $defaultProcessConfiguration;
+            $localProcessingConfiguration['width'] = $this->defaultWidth . 'm';
+
+            $processedFile = $originalFile->process(
+                ProcessedFile::CONTEXT_IMAGECROPSCALEMASK,
+                $localProcessingConfiguration
+            );
+
+            $url = $configuration->getAbsRefPrefix() . $processedFile->getPublicUrl();
 
             $dataKey = $ignoredWidths[$width]['dataKey'];
             $srcset = $ignoredWidths[$width]['srcset'];


### PR DESCRIPTION
I added some code to enable the rendering of the original image as the biggest size configured via TypoScript. It also respects a random order of the configuration items.

It should solve issue no #18.